### PR TITLE
Sorting by contour info score

### DIFF
--- a/src/page_dewarp/spans.py
+++ b/src/page_dewarp/spans.py
@@ -62,7 +62,7 @@ def assemble_spans(name, small, pagemask, cinfo_list):
             edge = generate_candidate_edge(cinfo_i, cinfo_list[j])
             if edge is not None:
                 candidate_edges.append(edge)
-    candidate_edges.sort()  # sort candidate edges by score (lower is better)
+    candidate_edges.sort(key=lambda cinfo: cinfo[0])  # sort candidate edges by score (lower is better)
     for _, cinfo_a, cinfo_b in candidate_edges:  # for each candidate edge
         # if left and right are unassigned, join them
         if cinfo_a.succ is None and cinfo_b.pred is None:


### PR DESCRIPTION
I had a problem when using page-dewarp on an image which had too few spans from contours. 
When detecting spans from line detection, line 65 in spans.py throws an error:
`TypeError: '<' not supported between instances of 'ContourInfo' and 'ContourInfo'`
(Test image used: https://imgur.com/Pa92Hks)

With this fix, the code runs and produces good results, so I think I'm sorting by the score that you refer to in the comment on the same line 65.