### PR TITLE
Fix AttributeError by adding proj_x

### DIFF
--- a/src/page_dewarp/contours.py
+++ b/src/page_dewarp/contours.py
@@ -73,6 +73,9 @@ class ContourInfo:
             f"center={self.center}, tangent={self.tangent}, angle={self.angle}"
         )
 
+    def proj_x(self, point):
+        return np.dot(self.tangent, point.flatten() - self.center)
+
     def local_overlap(self, other):
         xmin = self.proj_x(other.point0)
         xmax = self.proj_x(other.point1)


### PR DESCRIPTION
Fixes #14 

This was important if you locally cloned the repository and then tried to pip install the cloned repository. It would throw this error any time you tried to dewarp an image.