### PR TITLE
Document and pyproject.toml config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,104 @@
+site_name: Page Dewarp
+site_author: Louis Maddox
+site_description: >-
+  Document image dewarping library using a cubic sheet model
+site_url: https://page-dewarp.readthedocs.io/
+repo_name: lmmx/page-dewarp
+repo_url: https://github.com/lmmx/page-dewarp
+strict: true
+watch: [src]
+
+extra_css:
+  - stylesheets/extra.css
+
+copyright: Copyright &copy; 2021-present Louis Maddox
+
+theme:
+  name: material
+  custom_dir: docs/theme
+  palette:
+    - scheme: default
+      primary: white
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - announce.dismiss
+    - content.tabs.link
+    - content.code.annotate
+    - content.code.copy
+    - header.autohide
+    - navigation.indexes
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.prune
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - search
+    - search.suggest
+  font:
+    text: Inter
+    code: Source Code Pro
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/lmmx
+  generator: false
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.blocks.definition
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+      noclasses: True
+      pygments_style: lovelace
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true
+
+plugins:
+  - autorefs
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src/*/]
+          options:
+            members_order: source
+            separate_signature: true
+            filters: ["!^_"]
+            docstring_options:
+              ignore_init_summary: true
+            merge_init_into_class: true
+            line_length: 88 # default: 60
+            # show_if_no_docstring: true
+            show_root_full_path: false
+            show_root_toc_entry: false
+            show_source: true
+            show_submodules: true
+            show_signature_annotations: true
+  - search
+  - section-index
+  - social:
+      cards_layout_options:
+        color: #de0
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Welcome to Page Dewarp: get_started.md
+  - Usage:
+      - User guide: usage/index.md
+      - usage/page_dewarp.md
+  - API Reference:
+      - APIs: api/index.md
+      - api/page_dewarp.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,62 @@
-[build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+[project]
+authors = [
+    {email = "louismmx@gmail.com", name = "Louis Maddox"},
+]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = []
+description = "Document image dewarping library using a cubic sheet model."
+keywords = []
+name = "page-dewarp"
+readme = "README.md"
+requires-python = ">=3.9,<3.11"
+version = "0.0.1"
+
+[project.urls]
+Homepage = "https://github.com/lmmx/page-dewarp"
+Repository = "https://github.com/lmmx/page-dewarp.git"
+
+[tool.isort]
+known_first_party = ["page_dewarp"]
+
+[tool.pdm]
+package-type = "application"
+
+[tool.pdm.dev-dependencies]
+develop = []
+docs = [
+    "mkdocs-material[recommended,imaging]>=9.5.2",
+    "mkdocs-section-index>=0.3.8",
+    "mkdocs>=1.5.3",
+    "mkdocstrings[python]>=0.24.0",
+    "urllib3<2",  # Vercel: https://github.com/squidfunk/mkdocs-material/discussions/6470
+]
+test = [
+    "pytest>=7.4.0",
+]
+
+[tool.ruff]
+ignore = ["C408", "C901", "E501", "E722", "E741"]
+ignore-init-module-imports = true
+select = ["C", "D", "E", "F", "I", "UP", "W"]
+
+[tool.ruff.isort]
+lines-after-imports = 2
+
+[tool.ruff.lint.isort]
+known-first-party = ["page_dewarp"]
+
+[tool.ruff.per-file-ignores]
+# Ignore `E401` (unused imports) in all `__init__.py` files.
+"__init__.py" = ["E401", "F401"]
+
+[tool.tomlsort]
+all = true
+in_place = true
+spaces_before_inline_comment = 2
+spaces_indent_inline_array = 4
+trailing_comma_inline_array = true


### PR DESCRIPTION
- Introduce a mkdocs website using mkdocstrings.
- Fill out `pyproject.toml` (and drop `setuptools-scm` along the way)
