### PR TITLE
Fix error: (-215:Assertion failed) bug where image coords are of wron…

### DIFF
--- a/src/page_dewarp/dewarp.py
+++ b/src/page_dewarp/dewarp.py
@@ -59,6 +59,9 @@ class RemappedImage:
             image_y_coords, (width, height), interpolation=INTER_CUBIC
         )
         img_gray = cvtColor(img, COLOR_RGB2GRAY)
+        # Ensure image_x_coords and image_y_coords are of the correct type
+        image_x_coords = image_x_coords.astype(np.float32)
+        image_y_coords = image_y_coords.astype(np.float32)
         remapped = remap(
             img_gray,
             image_x_coords,


### PR DESCRIPTION
…g type

```
results % page-dewarp ../example_input/linguistics_thesis_a.jpg  Loaded linguistics_thesis_a.jpg at size='3456x4608' --> resized='494x658'
  got 20 spans with 161 points.
  initial objective is 0.02476134606067954
  optimizing 189 parameters...
  optimization took 2.06 sec.
  final objective is 0.0006459224174503983
  got page dims 1.2256983872644855 x 1.875175454180486
  output will be 2832x4320
Traceback (most recent call last):
  File "/Users/ant/Documents/Programowanie/python/.venv/bin/page-dewarp", line 8, in <module>
    sys.exit(main())
  File "/Users/ant/Documents/Programowanie/python/.venv/lib/python3.10/site-packages/page_dewarp/__main__.py", line 21, in main
    processed_img = WarpedImage(imgfile)
  File "/Users/ant/Documents/Programowanie/python/.venv/lib/python3.10/site-packages/page_dewarp/image.py", line 85, in __init__
    self.threshold(page_dims, params)
  File "/Users/ant/Documents/Programowanie/python/.venv/lib/python3.10/site-packages/page_dewarp/image.py", line 89, in threshold
    remap = RemappedImage(self.stem, self.cv2_img, self.small, page_dims, params)
  File "/Users/ant/Documents/Programowanie/python/.venv/lib/python3.10/site-packages/page_dewarp/dewarp.py", line 67, in __init__
    remapped = remap(
cv2.error: OpenCV(4.10.0) /Users/xperience/GHA-Actions-OpenCV/_work/opencv-python/opencv-python/opencv/modules/imgproc/src/imgwarp.cpp:1912: error: (-215:Assertion failed) ((map1.type() == CV_32FC2 || map1.type() == CV_16SC2) && map2.empty()) || (map1.type() == CV_32FC1 && map2.type() == CV_32FC1) in function 'remap'
```