### PR TITLE
backfill changelog

### DIFF
--- a/news/scripts/build_changelog.sh
+++ b/news/scripts/build_changelog.sh
@@ -1,1 +1,13 @@
-towncrier build --version $(pdm show --version --quiet)
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+version="$1"
+
+# Remove the 'v' prefix if present
+version="${version#v}"
+
+towncrier build --version "$version"

--- a/news/scripts/create_news_fragments.sh
+++ b/news/scripts/create_news_fragments.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+# Function to check if a command exists
+command_exists() { command -v "$1" >/dev/null 2>&1 ; }
+
+# Check for required commands
+required_commands=("jq" "gh" "git" "sed" "tr")
+missing_commands=()
+
+for cmd in "${required_commands[@]}"; do
+    if ! command_exists "$cmd"; then
+        missing_commands+=("$cmd")
+    fi
+done
+
+if [ ${#missing_commands[@]} -ne 0 ]; then
+    echo "Error: The following required commands are missing:" >&2
+    printf " - %s\n" "${missing_commands[@]}" >&2
+    echo "Please install these commands and try again." >&2
+    exit 1
+fi
+
 # Ensure the news directory exists: do not proceed otherwise
 root_hint="(Hint: run this script from the repo root)"
 newsdir="news"

--- a/news/scripts/create_news_fragments.sh
+++ b/news/scripts/create_news_fragments.sh
@@ -22,11 +22,12 @@ fi
 
 # Ensure the news directory exists: do not proceed otherwise
 root_hint="(Hint: run this script from the repo root)"
+delete_hint="(Hint: it can be deleted with `rm -rf news/fragments/`)"
 newsdir="news"
 [ -d "$newsdir" ] || { echo "Error: The directory $newsdir does not exist. $root_hint" >&2; exit 1; }
 # Ensure the fragments directory does not exist: do not assume it can be deleted (use PDM erase-history script)
 frags="$newsdir/fragments"
-[ ! -d "$frags" ] || { echo "Error: The directory $frags already exists. $root_hint" >&2; exit 1; }
+[ ! -d "$frags" ] || { echo "Error: The directory $frags already exists. $delete_hint" >&2; exit 1; }
 mkdir "$frags"
 
 # Function to determine change type based on commit message or PR labels

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Function to get the latest version
+get_latest_version() { git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0" ; }
+
+# Function to get the commit hash for a version or commit message
+get_commit_hash() {
+    local version_or_message="$1"
+    if [[ "$version_or_message" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        git rev-list -n 1 "$version_or_message" 2>/dev/null
+    else
+        git log --format="%H" --grep="$version_or_message" -n 1
+    fi
+}
+
+# Function to generate changelog for a specific range
+generate_changelog() {
+    local start_commit="$1"
+    local end_commit="$2"
+    local version="$3"
+
+    echo "Generating changelog for version $version..."
+    ./news/scripts/create_news_fragments.sh "$start_commit" "$end_commit"
+    ./news/scripts/build_changelog.sh "$version"
+    ./news/scripts/erase_news_fragments.sh
+}
+
+# Main script logic
+latest_tag=$(get_latest_version)
+latest_commit=$(git rev-parse HEAD)
+
+if [[ "$1" == "next" ]]; then
+    # Generate changelog for the next (unreleased) version
+    start_commit=$(get_commit_hash "$latest_tag")
+    generate_changelog "$start_commit" "$latest_commit" "next"
+elif [[ "$1" == "all" ]]; then
+    # Generate changelog for all versions
+    versions=($(git tag --sort=-v:refname))
+    previous_commit=""
+
+    for version in "${versions[@]}"; do
+        current_commit=$(get_commit_hash "$version")
+        if [[ -n "$previous_commit" ]]; then
+            generate_changelog "$current_commit" "$previous_commit" "$version"
+        fi
+        previous_commit="$current_commit"
+    done
+
+    # Generate changelog for the initial version
+    initial_commit=$(git rev-list --max-parents=0 HEAD)
+    generate_changelog "$initial_commit" "$previous_commit" "${versions[-1]}"
+
+    # Generate changelog for unreleased changes
+    generate_changelog "$previous_commit" "$latest_commit" "next"
+else
+    echo "Usage: $0 [next|all]"
+    exit 1
+fi

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -6,10 +6,14 @@ get_latest_version() { git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0
 # Function to get the commit hash for a version or commit message
 get_commit_hash() {
     local version_or_message="$1"
-    if [[ "$version_or_message" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        git rev-list -n 1 "$version_or_message" 2>/dev/null
+    if [[ "$version_or_message" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        # echo "Looking up $version_or_message with git rev-list"
+        local version_tag="$version_or_message"
+        git rev-list -n 1 "$version_tag" 2>/dev/null
     else
-        git log --format="%H" --grep="$version_or_message" -n 1
+        # echo "Looking up commit hash with git log --format='%H' --grep=$version_or_message -n 1"
+        local commit_message="$version_or_message"
+        git log --format="%H" --grep="$commit_message" -n 1
     fi
 }
 
@@ -18,6 +22,10 @@ generate_changelog() {
     local start_commit="$1"
     local end_commit="$2"
     local version="$3"
+
+    [[ -n "$start_commit" ]] || { echo "Error: start_commit is empty" >&2; return 1; }
+    [[ -n "$end_commit" ]] || { echo "Error: end_commit is empty" >&2; return 1; }
+    [[ -n "$version" ]] || { echo "Error: version is empty" >&2; return 1; }
 
     echo "Generating changelog for version $version..."
     ./news/scripts/create_news_fragments.sh "$start_commit" "$end_commit"
@@ -28,29 +36,42 @@ generate_changelog() {
 # Main script logic
 latest_tag=$(get_latest_version)
 latest_commit=$(git rev-parse HEAD)
+initial_commit=$(git rev-list --max-parents=0 HEAD)
+
+echo "Script running with argument: $1"
+echo "Latest tag: $latest_tag"
+echo "Latest commit: $latest_commit"
+echo "Initial commit: $initial_commit"
+echo
 
 if [[ "$1" == "next" ]]; then
-    # Generate changelog for the next (unreleased) version
     start_commit=$(get_commit_hash "$latest_tag")
+    echo "Looked up start commit from get_commit_hash $latest_tag as $start_commit"
+    echo "Generating changelog for the next (unreleased) version: start_commit=$start_commit, latest_commit=$latest_commit, version=next"
     generate_changelog "$start_commit" "$latest_commit" "next"
 elif [[ "$1" == "all" ]]; then
     # Generate changelog for all versions
-    versions=($(git tag --sort=-v:refname))
-    previous_commit=""
+    versions=($(git tag --sort=v:refname))
+    previous_commit="$initial_commit"
+    echo "Initialised previous_commit as initial commit ($initial_commit)."
 
     for version in "${versions[@]}"; do
+        echo
+        echo "Looping through versions: on version=$version"
         current_commit=$(get_commit_hash "$version")
+        echo "Looked up current commit from get_commit_hash $version as $current_commit"
         if [[ -n "$previous_commit" ]]; then
+            echo "Generating changelog for $version: current_commit=$current_commit, previous_commit=$previous_commit, version=$version"
             generate_changelog "$current_commit" "$previous_commit" "$version"
         fi
         previous_commit="$current_commit"
     done
 
-    # Generate changelog for the initial version
-    initial_commit=$(git rev-list --max-parents=0 HEAD)
+    echo
+    echo "Generating changelog for the initial version: initial_commit=$initial_commit, previous_commit=$previous_commit, version=${versions[-1]}"
     generate_changelog "$initial_commit" "$previous_commit" "${versions[-1]}"
 
-    # Generate changelog for unreleased changes
+    echo "Generating changelog for unreleased changes: previous_commit=$previous_commit, latest_commit=$latest_commit, version=next"
     generate_changelog "$previous_commit" "$latest_commit" "next"
 else
     echo "Usage: $0 [next|all]"

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -63,14 +63,15 @@ elif [[ "$1" == "all" ]]; then
         echo "Looked up current commit from get_commit_hash $version as $current_commit"
         if [[ -n "$previous_commit" ]]; then
             echo "Generating changelog for $version: current_commit=$current_commit, previous_commit=$previous_commit, version=$version"
-            echo generate_changelog "$current_commit" "$previous_commit" "$version"
+            generate_changelog "$current_commit" "$previous_commit" "$version"
         fi
+        read dummyvar
         previous_commit="$current_commit"
     done
 
     echo
     echo "Generating changelog for unreleased changes: previous_commit=$previous_commit, latest_commit=$latest_commit, version=next"
-    echo generate_changelog "$previous_commit" "$latest_commit" "next"
+    generate_changelog "$previous_commit" "$latest_commit" "next"
 else
     echo "Usage: $0 [next|all]"
     exit 1

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -51,8 +51,10 @@ echo
 if [[ "$1" == "next" ]]; then
     start_commit=$(get_commit_hash "$latest_tag")
     echo "Looked up start commit from get_commit_hash $latest_tag as $start_commit"
-    echo "Generating changelog for the next (unreleased) version: start_commit=$start_commit, latest_commit=$latest_commit, version=next"
-    echo generate_changelog "$start_commit" "$latest_commit" "next"
+    current_version=$(pdm show --version --quiet)
+    version="($current_version++)"
+    echo "Generating changelog for the next (unreleased) version: start_commit=$start_commit, latest_commit=$latest_commit, version=$version"
+    generate_changelog "$start_commit" "$latest_commit" "$version"
 elif [[ "$1" == "all" ]]; then
     # Generate changelog for all versions
     versions=($(git tag --sort=v:refname))
@@ -67,14 +69,16 @@ elif [[ "$1" == "all" ]]; then
         echo "Looked up current commit from get_commit_hash $version as $current_commit"
         if [[ -n "$previous_commit" ]]; then
             echo "Generating changelog for $version: current_commit=$current_commit, previous_commit=$previous_commit, version=$version"
-            generate_changelog "$current_commit" "$previous_commit" "$version"
+            generate_changelog "$previous_commit" "$current_commit" "$version"
         fi
         previous_commit="$current_commit"
     done
 
     echo
     echo "Generating changelog for unreleased changes: previous_commit=$previous_commit, latest_commit=$latest_commit, version=next"
-    generate_changelog "$previous_commit" "$latest_commit" "next"
+    current_version=$(pdm show --version --quiet)
+    version="($current_version++)"
+    generate_changelog "$previous_commit" "$latest_commit" "$version"
 else
     echo "Usage: $0 [next|all]"
     exit 1

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -48,7 +48,7 @@ if [[ "$1" == "next" ]]; then
     start_commit=$(get_commit_hash "$latest_tag")
     echo "Looked up start commit from get_commit_hash $latest_tag as $start_commit"
     echo "Generating changelog for the next (unreleased) version: start_commit=$start_commit, latest_commit=$latest_commit, version=next"
-    generate_changelog "$start_commit" "$latest_commit" "next"
+    echo generate_changelog "$start_commit" "$latest_commit" "next"
 elif [[ "$1" == "all" ]]; then
     # Generate changelog for all versions
     versions=($(git tag --sort=v:refname))
@@ -62,17 +62,17 @@ elif [[ "$1" == "all" ]]; then
         echo "Looked up current commit from get_commit_hash $version as $current_commit"
         if [[ -n "$previous_commit" ]]; then
             echo "Generating changelog for $version: current_commit=$current_commit, previous_commit=$previous_commit, version=$version"
-            generate_changelog "$current_commit" "$previous_commit" "$version"
+            echo generate_changelog "$current_commit" "$previous_commit" "$version"
         fi
         previous_commit="$current_commit"
     done
 
     echo
     echo "Generating changelog for the initial version: initial_commit=$initial_commit, previous_commit=$previous_commit, version=${versions[-1]}"
-    generate_changelog "$initial_commit" "$previous_commit" "${versions[-1]}"
+    echo generate_changelog "$initial_commit" "$previous_commit" "${versions[-1]}"
 
     echo "Generating changelog for unreleased changes: previous_commit=$previous_commit, latest_commit=$latest_commit, version=next"
-    generate_changelog "$previous_commit" "$latest_commit" "next"
+    echo generate_changelog "$previous_commit" "$latest_commit" "next"
 else
     echo "Usage: $0 [next|all]"
     exit 1

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -29,8 +29,12 @@ generate_changelog() {
 
     echo "Generating changelog for version $version..."
     ./news/scripts/create_news_fragments.sh "$start_commit" "$end_commit"
+    echo "Created news fragments"
     ./news/scripts/build_changelog.sh "$version"
-    ./news/scripts/erase_news_fragments.sh
+    echo "Built changelog"
+    rm -rf ./news/fragments/
+    echo "Finished generating changelog (deleted fragments directory)"
+    echo
 }
 
 # Main script logic
@@ -65,7 +69,6 @@ elif [[ "$1" == "all" ]]; then
             echo "Generating changelog for $version: current_commit=$current_commit, previous_commit=$previous_commit, version=$version"
             generate_changelog "$current_commit" "$previous_commit" "$version"
         fi
-        read dummyvar
         previous_commit="$current_commit"
     done
 

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -52,7 +52,8 @@ if [[ "$1" == "next" ]]; then
     start_commit=$(get_commit_hash "$latest_tag")
     echo "Looked up start commit from get_commit_hash $latest_tag as $start_commit"
     current_version=$(pdm show --version --quiet)
-    version="($current_version++)"
+    # version="($current_version++)"
+    version="Unreleased"
     echo "Generating changelog for the next (unreleased) version: start_commit=$start_commit, latest_commit=$latest_commit, version=$version"
     generate_changelog "$start_commit" "$latest_commit" "$version"
 elif [[ "$1" == "all" ]]; then
@@ -77,7 +78,8 @@ elif [[ "$1" == "all" ]]; then
     echo
     echo "Generating changelog for unreleased changes: previous_commit=$previous_commit, latest_commit=$latest_commit, version=next"
     current_version=$(pdm show --version --quiet)
-    version="($current_version++)"
+    version="Unreleased"
+    # version="($current_version++)"
     generate_changelog "$previous_commit" "$latest_commit" "$version"
 else
     echo "Usage: $0 [next|all]"

--- a/news/scripts/version_based_changelog.sh
+++ b/news/scripts/version_based_changelog.sh
@@ -52,6 +52,7 @@ if [[ "$1" == "next" ]]; then
 elif [[ "$1" == "all" ]]; then
     # Generate changelog for all versions
     versions=($(git tag --sort=v:refname))
+
     previous_commit="$initial_commit"
     echo "Initialised previous_commit as initial commit ($initial_commit)."
 
@@ -68,9 +69,6 @@ elif [[ "$1" == "all" ]]; then
     done
 
     echo
-    echo "Generating changelog for the initial version: initial_commit=$initial_commit, previous_commit=$previous_commit, version=${versions[-1]}"
-    echo generate_changelog "$initial_commit" "$previous_commit" "${versions[-1]}"
-
     echo "Generating changelog for unreleased changes: previous_commit=$previous_commit, latest_commit=$latest_commit, version=next"
     echo generate_changelog "$previous_commit" "$latest_commit" "next"
 else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,18 +47,18 @@ version = "0.1.5"
 [project.scripts]
 page-dewarp = "page_dewarp.__main__:main"
 
+[project.urls]
+Homepage = "https://github.com/lmmx/page-dewarp"
+Repository = "https://github.com/lmmx/page-dewarp.git"
+
 # The following scripts are package development release reminders and/or shortcuts
 [tool.pdm.scripts]
 version = "bash news/scripts/get_version.sh"
 erase-news = "rm -rf news/fragments"
 write-news = "bash news/scripts/version_based_changelog.sh next"
 write-all-news = "bash news/scripts/version_based_changelog.sh all"
-build-news= "bash news/scripts/build_changelog.sh"
+build-news = "bash news/scripts/build_changelog.sh"
 refresh-changelog = "echo 'pdm run erase-news && pdm run write-news && pdm run build-news'"
-
-[project.urls]
-Homepage = "https://github.com/lmmx/page-dewarp"
-Repository = "https://github.com/lmmx/page-dewarp.git"
 
 [tool.towncrier]
 package = "page_dewarp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ page-dewarp = "page_dewarp.__main__:main"
 [tool.pdm.scripts]
 version = "bash news/scripts/get_version.sh"
 erase-news = "rm -rf news/fragments"
-write-news = "bash news/scripts/create_news_fragments.sh"
+write-news = "bash news/scripts/version_based_changelog.sh next"
+write-all-news = "bash news/scripts/version_based_changelog.sh all"
 build-news= "bash news/scripts/build_changelog.sh"
 refresh-changelog = "echo 'pdm run erase-news && pdm run write-news && pdm run build-news'"
 


### PR DESCRIPTION
- **chore: ensure that all commands are available before running the towncrier script**
- **chore: suggest deleting the news/fragments dir if it already exists**
- **feat: version-based changelog generator (for backfilling SCM tag-based versions)**
- **feat: modify news fragment script to accept commit hashes (rather than hardcoding a date range)**
- **feat: split changelog script to create news fragments (2 modes: 'next' and 'all')**
- **fix: proceed forward from initial commit through all tags**
- **revert: turn changelog debugging back on**
- **chore: remove initial version changelog (already handled by loop initialised from initial commit)**
- **chore: step through versions with a breakpoint**
- **fix: towncrier build script accepts a version parameter**
- **chore: remove breakpoints, add logging to script calling**
- **fix: correct parameter order of commits to `generate_changelog`**
- **chore: rename new releases in the log to 'Unreleased'**
