### PR TITLE
python version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![pdm-managed](https://img.shields.io/badge/pdm-managed-blueviolet)](https://pdm.fming.dev)
-[![Supported Python versions](https://img.shields.io/pypi/v/page-dewarp.svg)](https://pypi.python.org/pypi/page-dewarp)
+[![PyPI](https://img.shields.io/pypi/v/page-dewarp.svg)](https://pypi.org/projects/page-dewarp)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/page-dewarp.svg)](https://pypi.org/project/page-dewarp)
 [![License](https://img.shields.io/pypi/l/page-dewarp.svg)](https://pypi.python.org/pypi/page-dewarp)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/lmmx/page-dewarp/master.svg)](https://results.pre-commit.ci/latest/github/lmmx/page-dewarp/master)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To install from PyPI, optionally using [uv](https://docs.astral.sh/uv/) (recomme
 
 - `uv pip install page-dewarp` (recommended)
 - or `pip install page-dewarp`
-```
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # page-dewarp
 
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![pdm-managed](https://img.shields.io/badge/pdm-managed-blueviolet)](https://pdm.fming.dev)
+[![Supported Python versions](https://img.shields.io/pypi/v/page-dewarp.svg)](https://pypi.python.org/pypi/page-dewarp)
+[![License](https://img.shields.io/pypi/l/page-dewarp.svg)](https://pypi.python.org/pypi/page-dewarp)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/lmmx/page-dewarp/master.svg)](https://results.pre-commit.ci/latest/github/lmmx/page-dewarp/master)
+
 Document image dewarping library using a cubic sheet model
 
 Python 3 library for page dewarping and thresholding,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install from PyPI, optionally using [uv](https://docs.astral.sh/uv/) (recomme
 
 ## Dependencies
 
-Python 3.9+ and NumPy, SciPy, SymPy, Matplotlib, OpenCV, and TOML Kit are required to run `page-dewarp`.
+Python 3.9+ and NumPy, SciPy, SymPy, Matplotlib and OpenCV are required to run `page-dewarp`.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install from PyPI, optionally using [uv](https://docs.astral.sh/uv/) (recomme
 
 ## Dependencies
 
-Python 3.8+ and NumPy, SciPy, SymPy, Matplotlib, OpenCV, and TOML Kit are required to run `page-dewarp`.
+Python 3.9+ and NumPy, SciPy, SymPy, Matplotlib, OpenCV, and TOML Kit are required to run `page-dewarp`.
 
 ## Background
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Programming Language :: Python :: 3",
   "Operating System :: OS Independent",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
- **docs: README badges**
- **docs: Python version support badge**
- **fix: I think Python version classifiers don't show on badges if you include a v3**
- **docs: repo formatting got messed up, oops**
- **docs: update min. version in README**
- **revert: remove docs on TOML dependency**
