### PR TITLE
enforce minimum python version

### DIFF
--- a/src/page_dewarp/__init__.py
+++ b/src/page_dewarp/__init__.py
@@ -1,3 +1,6 @@
+from .check_version import enforce_version
 from .__main__ import main
 
 __all__ = ("main",)
+
+enforce_version()

--- a/src/page_dewarp/__main__.py
+++ b/src/page_dewarp/__main__.py
@@ -13,6 +13,7 @@ from .snoopy import snoop
 
 enforce_version()
 
+
 @snoop()
 def main():
     parser = ArgParser()

--- a/src/page_dewarp/__main__.py
+++ b/src/page_dewarp/__main__.py
@@ -1,6 +1,7 @@
 import msgspec
 from cv2 import namedWindow
 
+from .check_version import enforce_version
 from .cli import ArgParser
 from .image import WarpedImage
 from .options import Config
@@ -10,6 +11,7 @@ from .snoopy import snoop
 # for some reason pylint complains about cv2 members being undefined :(
 # pylint: disable=E1101
 
+enforce_version()
 
 @snoop()
 def main():

--- a/src/page_dewarp/check_version.py
+++ b/src/page_dewarp/check_version.py
@@ -4,11 +4,12 @@ __all__ = ("enforce_version",)
 
 MIN_SUPPORTED_V = (3, 9)
 
+
 def enforce_version() -> None:
     """Raise `SystemExit` if running on an unsupported Python version."""
-    if sys.version_info < MIN_SUPPORTED_V:
-        user_warn = f"Python {sys.version_info.major}.{sys.version_info.minor} is not supported"
-        msg = f"{user_warn}: Please use Python {'.'.join(min_supported_v)} or higher.\n"
+    if (ver := sys.version_info) < MIN_SUPPORTED_V:
+        user_warn = f"Python {ver.major}.{ver.minor} is not supported"
+        msg = f"{user_warn}: Please use Python {'.'.join(MIN_SUPPORTED_V)} or higher.\n"
         sys.stderr.write(msg)
         sys.exit(1)
     return

--- a/src/page_dewarp/check_version.py
+++ b/src/page_dewarp/check_version.py
@@ -1,0 +1,14 @@
+import sys
+
+__all__ = ("enforce_version",)
+
+MIN_SUPPORTED_V = (3, 9)
+
+def enforce_version() -> None:
+    """Raise `SystemExit` if running on an unsupported Python version."""
+    if sys.version_info < MIN_SUPPORTED_V:
+        user_warn = f"Python {sys.version_info.major}.{sys.version_info.minor} is not supported"
+        msg = f"{user_warn}: Please use Python {'.'.join(min_supported_v)} or higher.\n"
+        sys.stderr.write(msg)
+        sys.exit(1)
+    return


### PR DESCRIPTION
- **chore: exit early if running on unsupported Python version (resolves #35)**
- **fix: typo and small refactor**
