### PR TITLE
refactor(czkawka): cache test output images as string hashes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -25,7 +25,7 @@ ruff-check:
       .
 
 test *args:
-    pytest {{args}} < /dev/null
+    pytest {{args}}
 
 test-ci *args:
     #!/usr/bin/env -S bash -euo pipefail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Multimedia :: Graphics :: Graphics Conversion",
   "Topic :: Scientific/Engineering :: Image Processing",
 ]
@@ -41,6 +42,7 @@ version = "0.2.0"
 [dependency-groups]
 build = ["maturin>=1.9.3", "patchelf>=0.17.2.4"]
 dev = [
+  "pdbpp>=0.11.7",
   "pdm-bump>=0.9.10",
   "pdm>=2.22.3",
   "pre-commit>=4.1.0",
@@ -59,10 +61,7 @@ docs = [
   "urllib3<2",
   "mdx-truly-sane-lists",
 ]
-test = [
-    "czkawka>=0.0.7",
-    "pytest>=7.4.0",
-]
+test = ["czkawka>=0.1.1", "inline-snapshot>=0.30.1", "pytest>=7.4.0"]
 
 [project.scripts]
 page-dewarp = "page_dewarp.__main__:main"

--- a/tests/image_outputs_test.py
+++ b/tests/image_outputs_test.py
@@ -4,11 +4,12 @@ This module tests that the `page-dewarp` command produces the expected
 thresholded image output for a sample input.
 """
 
-import filecmp
 import subprocess
 from pathlib import Path
 
 import pytest
+from czkawka import ImageSimilarity
+from inline_snapshot import snapshot
 
 
 repo_root = Path(__file__).parents[1]
@@ -25,12 +26,12 @@ def temp_dir(tmp_path):
 def test_page_dewarp_output(temp_dir):
     """Check that the CLI produces the expected thresholded image from sample input."""
     input_file = example_inputs_dir / "boston_cooking_a.jpg"
-    expected_output = example_outputs_dir / "boston_cooking_a_thresh.png"
     output_file = temp_dir / "boston_cooking_a_thresh.png"
 
     subprocess.run(["page-dewarp", str(input_file)], cwd=temp_dir, check=True)
 
     assert output_file.exists(), "Output file was not created"
-    assert filecmp.cmp(output_file, expected_output), (
-        "Output file does not match expected output"
-    )
+
+    finder = ImageSimilarity()
+    output_hash = finder.hash_image(output_file)
+    assert output_hash == snapshot("8LS0tOSwvLQ")

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978, upload-time = "2024-11-30T04:30:14.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918, upload-time = "2024-11-30T04:30:10.946Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -363,82 +372,82 @@ wheels = [
 
 [[package]]
 name = "czkawka"
-version = "0.0.7"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/81/d31be417f93d8b238f38149131f81f09a499493f568654f182345b0c8558/czkawka-0.0.7.tar.gz", hash = "sha256:1ab174d0663d1408da63cbef1fd263af7f3d8a7cf96aab21fbc4787ddca928e8", size = 122198, upload-time = "2025-10-20T14:19:56.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/61/22956bc441ad992a6c78ab7d8c8677d790dd42ec8ecd1969bcab0a1faf42/czkawka-0.1.1.tar.gz", hash = "sha256:b6a38fd7bdccc1b998ea082f0b7aa7e87d8f7b0d2a3a1927a697b94bbd35fa26", size = 131610, upload-time = "2025-10-20T21:43:45.68Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/c2/67b48f733e0f095476a4010180790a21dc4e0d7fc983c1e1fa47c5271533/czkawka-0.0.7-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:cf90dad824d41a4a727cb0f26f3b2aacaa1c122d2263e6ab06ec1b00ab054b59", size = 3572662, upload-time = "2025-10-20T14:17:51.786Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/63/e947634474392a247bf92ee0b4338ef80f19b4642afafe21adafdb42bdf5/czkawka-0.0.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ebf754e5db315e6d41150d2baed6a5ec9cb20664d14d4f91bcc868954236b39", size = 3013646, upload-time = "2025-10-20T14:18:40.87Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/33/1216971a572605ac79b8e133d6da9c7ee6b45f604a4d21ed5c5317ff201b/czkawka-0.0.7-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:88c3f216b2cfa2cd8bf4f2f17b4c0aab1baa4912c8a5aa9fda39048a4e8aec46", size = 3179725, upload-time = "2025-10-20T14:17:37.862Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/6a/0c1feb9a345d81416e4135f28dc7064c2244ef839f9436a3607e19646e3f/czkawka-0.0.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25eab33de53de7d4f6a942a16a85798a494d8ffef38dbf40c7d902787404c656", size = 3594208, upload-time = "2025-10-20T14:19:50.322Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1f/a034449cd4bb9d2ee4adaff5a4ce301bc47a4ddbaf310c7bdf5bc69a9908/czkawka-0.0.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c754dbbc82c22aaf6613a8ddfa1ef7985495d6da0efa1d52f3b38efd5df9bfd", size = 3480651, upload-time = "2025-10-20T14:19:05.727Z" },
-    { url = "https://files.pythonhosted.org/packages/42/8c/666da2a01a2bb7c6c88da8a2b063dbb3f9180b5e0b930443567273a89f3c/czkawka-0.0.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0556788f3fe9a30e33f923e25fc1cd9c08e9005e90c9d1bf3b1b9336c8f0499d", size = 3395459, upload-time = "2025-10-20T14:17:53.442Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/20/4aa4c5f0dbecc660bd827394bc4a68448069a45bbf1ef3039608aa4eab46/czkawka-0.0.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8ab26c9c02f3b365c98691ade5d3d1ca3ee40b658b3b769f3c180c143b75c349", size = 3192975, upload-time = "2025-10-20T14:17:26.146Z" },
-    { url = "https://files.pythonhosted.org/packages/65/0b/23dbe97ec2324f60ab92382266d9076b7a045c8643287ae775d987b2d9b4/czkawka-0.0.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e534c6bc7026d8d9db06b16148bb0008ee079a4676b9a0499bff69c7ddb2d8d4", size = 3440870, upload-time = "2025-10-20T14:19:55.435Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/ed/314ee10bdae4cb358d36ba1f805b32289cbd4b73361331c261b684d6693e/czkawka-0.0.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:22a8157e5e0a904c004042696bb656ac779293ddcb45f035f5c6b401a0d64d13", size = 3561406, upload-time = "2025-10-20T14:19:09.255Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ab/9092189edcf9d5b6189f917d2848b0c419b329cf1d02bec0e4d299ac32bd/czkawka-0.0.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:abe790d24c47389f0c1e750fdbda290965139ecf9d1238ea4f4a34fef6c96303", size = 3583988, upload-time = "2025-10-20T14:19:23.778Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/e9/bf12f74012ab5b24f6dbc2a44721ab0a8e69d9a549203b03419afc40cb2a/czkawka-0.0.7-cp310-cp310-win_amd64.whl", hash = "sha256:e836f959654be214ab70092fe802af138c23619ae45d787fd44b573ead76eae1", size = 3066572, upload-time = "2025-10-20T14:19:39.01Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/02/4b6e5e94b522e25980bfb4dc49eca42f85726d7887516e538e7bb0c15518/czkawka-0.0.7-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c2646888db808255169efdcab0d0ec92c2375b3beb0f6d1937584b0c157939f3", size = 3215729, upload-time = "2025-10-20T14:18:11.13Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/7a/362db67eb0ee02281795b2a6296c8f5bbc6a3d346af234508d7cd0d44e40/czkawka-0.0.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:02653f6530f7e46b689392a5918f526997c1f95f8aebc5cef7cbd608bf291d1f", size = 2837604, upload-time = "2025-10-20T14:18:46.404Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/0d/6009f023399625be607f4f3e5ed6bacc59082a83d4392d0e9ded39e494bc/czkawka-0.0.7-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e128998151344e9b9bb4d75744e85eef706e1f52258863953cb9db8d8cadbbdf", size = 3572491, upload-time = "2025-10-20T14:18:28.992Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/2e/2b3ceb5c391f273b962c03a7043c91fe736ab60ede4ba9e6b312c27bab34/czkawka-0.0.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b2bebebeb25e1c0d21c56af94331a8e5206fb710d41b772cb374adbb0640b", size = 3013533, upload-time = "2025-10-20T14:19:12.434Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/c6/7f63147a2712fbfd8c14333cba6e59ec36aa5090f71cfd0ba78358930a5c/czkawka-0.0.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ae4077e39c68981808508d96c0b44ebcc5f9f151ce97a5e90303c7f1c5942c8d", size = 3179858, upload-time = "2025-10-20T14:19:31.849Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/80/7e5359c0e065883e6eee82b272e814afc9ee3cdff91e7b9b32fc89cc2bfb/czkawka-0.0.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d00db3050ddfd1383622d27aa3d1c2e92dfae46c7a4f09e837699b12b8e19e", size = 3594320, upload-time = "2025-10-20T14:19:03.729Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/b1/21ea6424f8071cb2a29d6c36f08a28c563ff2d20f0f25e34b19521f755ec/czkawka-0.0.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe5ddec8bb12d0d3d2c545b76bd887413fd0497068c8f2dbb4fee32c35f93c8", size = 3480453, upload-time = "2025-10-20T14:18:48.701Z" },
-    { url = "https://files.pythonhosted.org/packages/28/79/0614e9711cf158beafb04e133557fa8843b19d40534e8a92ef8ad40c8541/czkawka-0.0.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d31c16f65035cc3ccab3993630621cde65bafdfdabd5dcc2e77c0b13a8c0683", size = 3395322, upload-time = "2025-10-20T14:18:21.643Z" },
-    { url = "https://files.pythonhosted.org/packages/62/2d/64af5a3350dc9d84667bec242af134001f62090b2784551c2f817926704c/czkawka-0.0.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f474026dca09e076fbda40656807c49a298e027240fb8059461c715ad37b2030", size = 3193122, upload-time = "2025-10-20T14:19:29.42Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d6/8d1141c7ef1d65f39f8f194c2bec4375293681f352d701086e3202a060e2/czkawka-0.0.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:7cf0deece4fc2a958dab672d131dc51d689720ba2c69a77348e6730eee5e7ce6", size = 3441203, upload-time = "2025-10-20T14:18:44.875Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/8a/92adff92e767d71ce45ce429ef3f9e635720dd930a1b86441f62a649dcb9/czkawka-0.0.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:66c800a22d1ceab317beb75947db6cae2087297d1801b56f8d43946e6d22b484", size = 3561436, upload-time = "2025-10-20T14:18:37.337Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c3/c4e035228b41285597ec8f9a2dd01423893895aa7e1f39f0b87b198566b0/czkawka-0.0.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:50939ca1c5695f940fb7366282bcde4cf1bf915de546d369ac33fbcb535f2fbe", size = 3583954, upload-time = "2025-10-20T14:19:19.829Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/7e/8dd04984205dc333bd33189b7b00efda38af12ff2b6a615a91ce6f263bb2/czkawka-0.0.7-cp311-cp311-win_amd64.whl", hash = "sha256:756e5f80ec947794cb08db1bfea29d013992a043226b2588bd59bd3f2ef026c1", size = 3066401, upload-time = "2025-10-20T14:19:13.918Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/7b/a8488e4c22c087f09c0929ea5291304df0c11d3eb659fcfba6ae74c743c7/czkawka-0.0.7-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:94f52d439663979e05e638041e5c04ab6c829c4e733b75ca34a0b17978b7d03a", size = 3214134, upload-time = "2025-10-20T14:18:51.828Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2f/10db183e85e70f6ff73e5d537dbc260f4a76250d0441960162c6dea40861/czkawka-0.0.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06c19dd2f241a3a36ded07c4b19119d2216082c0e03b10b32663cb4887d79001", size = 2836343, upload-time = "2025-10-20T14:19:27.907Z" },
-    { url = "https://files.pythonhosted.org/packages/05/44/df3f232536938eb33405bb3669725d490da319ca9b65d40a251f4b04f436/czkawka-0.0.7-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b0f836b06798f85fd76edac92a205facd617a965f9c10b76197f60390e93b02e", size = 3572277, upload-time = "2025-10-20T14:18:35.337Z" },
-    { url = "https://files.pythonhosted.org/packages/92/13/02f4297496eb53621c8057ebcf45bd72b04b801a9490eed877603e67e408/czkawka-0.0.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fa5c38681586cfaf9f7ec795081d564bc7f87824ad097c0e5ce94ea7d59e558", size = 3014497, upload-time = "2025-10-20T14:18:32.086Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b2/637aaa7d1b9f2853e42f3c66d6c6fef0b6a289f36afc7c141cb43788d904/czkawka-0.0.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:66181ce71a061f38de5587484fda6868111265faf23ec5c0e5f9786141a96238", size = 3179657, upload-time = "2025-10-20T14:17:36.144Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/05/22d40deb269822dc95f30db34d38946de1711a9a9e75e8bbe9ae04a10c6b/czkawka-0.0.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0898b7589eb7a0402bb94b3eb4143fea8177edc8c869b38b1dbf671795895cf9", size = 3594316, upload-time = "2025-10-20T14:17:59.076Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2d/30d01b5e97d1b047bd7c7d6ae017a7f1d468d81519249e1afe50f1b259e4/czkawka-0.0.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8e1df9772e520cdc762ab357013fe28a1c36d7649f15c1535c2094a74eda57bb", size = 3481526, upload-time = "2025-10-20T14:19:47.039Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/9f0445cdd94e409c1592e75ee3f8f94c5d31b3b08f21c459d7168175b8c3/czkawka-0.0.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3692ac092bc3e68eae0662e327d45e9bb61a8eeb927900d1a6ff6877eddcd9eb", size = 3395610, upload-time = "2025-10-20T14:17:41.889Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/7a/d156c58570093792fbd787bf5bc5321eff46aa212b8c7907d1a50b4ffb1b/czkawka-0.0.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:42cfaad7486e93094c363953db43eff8465a7b155eb0031a76133ae7741edc0e", size = 3193343, upload-time = "2025-10-20T14:19:43.806Z" },
-    { url = "https://files.pythonhosted.org/packages/af/ed/d665e32180e9b1e0100082ad1f92cbc47724bc324ef847ceac0ae0248c17/czkawka-0.0.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ccbef0b0fcf397592e4c7e516627de9daf10d8890e5478f6b0eb16d8ad0d81eb", size = 3441257, upload-time = "2025-10-20T14:19:02.158Z" },
-    { url = "https://files.pythonhosted.org/packages/af/74/135a35976cbb0ccf45545f060cbaa6f79e89b4686db3883d244a341a48a5/czkawka-0.0.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ba710fff0b4af8e4d8a817e3468b4789a0d70097ec336263d02ecb1e915f9bf6", size = 3561322, upload-time = "2025-10-20T14:17:24.312Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/18/f2a10bf05b07caeaacbd60ac87fea94d15940dec8be0832ddbec68ef02e2/czkawka-0.0.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a005b7e66ab386756ff128b833bf191bb8f8fbc8f07fcdd9047c9a75f1e59831", size = 3584312, upload-time = "2025-10-20T14:18:39.324Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/9d/05e82d199e1c1c05acceae06384b7fd70b3db0b411047de04629210f934f/czkawka-0.0.7-cp312-cp312-win_amd64.whl", hash = "sha256:0a68fa1db0d7a45fc5d96c78f9e8ca86444c792cd834d0a2b07c8493931d5100", size = 3066543, upload-time = "2025-10-20T14:19:07.277Z" },
-    { url = "https://files.pythonhosted.org/packages/24/09/d53e3d17a810b6e592821642a3970d602251b3798e4c2c30e92b625079ea/czkawka-0.0.7-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:c416eb0062edd2ffa7caf7520b566f6938afcc262ab3ba126c86c900a01ced88", size = 3214313, upload-time = "2025-10-20T14:17:46.101Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/72/ee8cda0713356ab3b5efe07c02e5d4799ae73efae48debafb59d5d3c8929/czkawka-0.0.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a2e20a0315308a26e96f416279629895707c46836585a5a651ee870833f20c38", size = 2836338, upload-time = "2025-10-20T14:19:51.976Z" },
-    { url = "https://files.pythonhosted.org/packages/48/8b/2921071d6c5a1a3ff516a46f9e1f72f306216a434d826309660e55aeb139/czkawka-0.0.7-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:88206590d942bd1e2ab4ab43ccd7c81bc577d3b06981f3847d9d374bbfb838cc", size = 3572287, upload-time = "2025-10-20T14:18:03.278Z" },
-    { url = "https://files.pythonhosted.org/packages/64/7c/96d26a78a01df812902ab1ce240ec4f8608fd4f51da958a82cb8659b60b2/czkawka-0.0.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c779f4105a1782cf26c3fca349df3ff95149079f252b05df504f73fd49044da0", size = 3014630, upload-time = "2025-10-20T14:17:39.488Z" },
-    { url = "https://files.pythonhosted.org/packages/85/5a/7dfe4e1455acc6789665fdbb561610c51bbb7395f3c6ee18772c46b03005/czkawka-0.0.7-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:799bbefbfc1edf43e737af1ef03e6b7ab03d9b86ece8d9f24491681660d5c57e", size = 3179762, upload-time = "2025-10-20T14:17:55.822Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bd/6444dd38959b397f7afe4f710992f7b5d5a2548db850b8385b41bdf3c788/czkawka-0.0.7-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3253a2833d593f877b10fc180a40f0907812e84e48aac7f7fecd0d8dacea4f4", size = 3594622, upload-time = "2025-10-20T14:19:53.817Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b7/91e75613856d4d281127e61cf73bd15cfba77dbaa67f9ab189a9e489c99c/czkawka-0.0.7-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:703d0870dbb25aefd99eab035ca6360aaac7636c448a034750aecb0250efba8b", size = 3481525, upload-time = "2025-10-20T14:19:48.713Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a5/1e85165bc794fb558af7954acfeed8dcb0d4ad57e8a43db10fd31b3b322f/czkawka-0.0.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:542c835487b9bbf20e6caf9f8d9722178002c00f9dc5850c7f87af9583da46c3", size = 3395862, upload-time = "2025-10-20T14:19:26.394Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/7a/4c7511b10b487d73d2c743a113a7029193845037a7d7911b2d75b08ebf99/czkawka-0.0.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0f58fdee984ed51d3ddd65e655a17d10e5b5758b30f8dfff93977e6fb8aedeb7", size = 3193256, upload-time = "2025-10-20T14:19:00.59Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/ea/39c2cc90d26fa5c586f9524aa5d61640d17326bf594f37d299784cee953c/czkawka-0.0.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9ed154347ce472fe96686ce9830ecf69b3dda2d0c547d1a114e7b7679b162d9f", size = 3441331, upload-time = "2025-10-20T14:17:47.785Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/d4/e864d599a3ff4d81454a8e3fb7b9c95a0421ee66d10fd9e9f36cce324250/czkawka-0.0.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:beeb7096357efe10396afd2c029d545c55d5f23cebf4b910112391d81292ea00", size = 3561378, upload-time = "2025-10-20T14:18:19.866Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b2/f600ee4e3068c33178f25b0263378b4d625abe6386da470144d8834ed317/czkawka-0.0.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f4f3ae2a00894347b274da8ede0e9bb0f485f4c20908a0d3b533e0dd448b95e8", size = 3584399, upload-time = "2025-10-20T14:18:12.989Z" },
-    { url = "https://files.pythonhosted.org/packages/40/69/a05237251e41a53a2c6b707b8148c1f91a934a5e84ad1b1a7b548b505ecc/czkawka-0.0.7-cp313-cp313-win_amd64.whl", hash = "sha256:7a84e282c995ea664dbe3a6ba45b4ab404ecf08adc4253c091bf8d781891ec2a", size = 3066636, upload-time = "2025-10-20T14:18:04.786Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2d/5bf53ed1928c44fbf786f4186715d2ba1eeb5320039fdb1334f4bc0da19f/czkawka-0.0.7-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e34f08a9ec57c9de0dd0b8a5e98a77bc43e6da55aa59049d657a9416786b1aaf", size = 3013568, upload-time = "2025-10-20T14:19:10.902Z" },
-    { url = "https://files.pythonhosted.org/packages/82/6c/feff8ae8119b48a53d484b49d098dde9037b461486627739389d6bfc59ce/czkawka-0.0.7-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc8d79c2370f5adbfb51f73df523bcb465d9798adbd25147b6901d424e2af29e", size = 3178624, upload-time = "2025-10-20T14:17:49.465Z" },
-    { url = "https://files.pythonhosted.org/packages/45/05/9d58911d994ced9945088397961a8512aeea46919a60a8d5e6fe95db07d8/czkawka-0.0.7-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8067f8ed0831125cb412df717bbfb5b04a2b91e036f5e079b0129738d81312a6", size = 3593806, upload-time = "2025-10-20T14:18:14.665Z" },
-    { url = "https://files.pythonhosted.org/packages/16/1f/e8e59b739ae617ec1c167a29aa6dadeb1c3399ccc0b318a6a9ef003dc3fa/czkawka-0.0.7-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80bd748780a2be91fb2f634a736cf657723ca410fab2db7efca3f151d89f5cfa", size = 3479520, upload-time = "2025-10-20T14:17:57.471Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b3/352bed4a15a7e2d65d4fe391c238dcb96c69bc9ee763c282c3ceb1ae9dbb/czkawka-0.0.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e362367ac404c1c7e70a5929ded3d5de496fecc94f258083e5f6246edfd32e69", size = 3192454, upload-time = "2025-10-20T14:19:22.099Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d2/810ea81a8b7df642ea8e44a3b95232e63daca9bf73f0df8e3ef80413e18f/czkawka-0.0.7-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:c3c8dc4b2bf69711c1cc6ca962c1897c323fa45e1a392980a9dbcd961e1c13ad", size = 3440145, upload-time = "2025-10-20T14:18:33.652Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ff/915e78303e711ccdd0a3abbe82dff31f6f17177a1e03bdceddba28adcfeb/czkawka-0.0.7-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:81d8eee5e8c2eda5412bba7021e839f726d7064465a58f784cb3c2c97c451375", size = 3560716, upload-time = "2025-10-20T14:17:28.91Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e0/e0dd503f0a5366dc29849324256ee1c6752c573326e2e88798191c80f6c0/czkawka-0.0.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e85b7e8c431ec0e2cc6fde24729dcc51061398524900371d31d6972007ea612", size = 3583574, upload-time = "2025-10-20T14:19:40.591Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/87/71e89ee527de072767ba1104b6d546e124085c3594fd28ef47511d6d95e5/czkawka-0.0.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8bada14cbd5ee6df8c14b75b2f98464e8e9b8f13abf69c3a17b4af65af67fd2d", size = 2836699, upload-time = "2025-10-20T14:18:54.865Z" },
-    { url = "https://files.pythonhosted.org/packages/25/bb/810b3769f445a4dc21f3246ec77328b0e91cc840e4b8f09d19d4e54c848c/czkawka-0.0.7-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:acbf6357337be1bd5e5fad041e2055ebcf3851ae5f1fd425b03c37db9a276398", size = 3572498, upload-time = "2025-10-20T14:19:15.959Z" },
-    { url = "https://files.pythonhosted.org/packages/89/02/358594a519cdb1548a686c203ba26b7857f21ba02c2fa4fde3f01d399f23/czkawka-0.0.7-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56dad6e4500af1f271fd2705dbfdab5fab452e10a8ac9cc6c4ff03bef5e44700", size = 3395911, upload-time = "2025-10-20T14:18:26.934Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/48/209233a4de600a02b4cfc2afb90f41237af80770bd334d42e9e468a28ff6/czkawka-0.0.7-cp314-cp314-win32.whl", hash = "sha256:293063d10f5687f668dbaea9a0a0feed7b20e6d0b0559d8b7dbb1063947a6c20", size = 2995929, upload-time = "2025-10-20T14:18:59.032Z" },
-    { url = "https://files.pythonhosted.org/packages/10/24/18e007a9a2588ce275854438c16d413accaeb3e8811b8620b2d3ecd192f1/czkawka-0.0.7-pp311-pypy311_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e0a9b466db9611527175c73d374c3296f90d08d460c7786d821b8c41a36a3376", size = 3572388, upload-time = "2025-10-20T14:18:25.389Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/56/cf2920ff78aa1f27c9e9401b8e3ae2371010979c5f488d41be6ad90ef038/czkawka-0.0.7-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53ccb16c4b81a3745145c1f3f0557026b0fb0568c96e3d56fce16d4de2acf9", size = 3013468, upload-time = "2025-10-20T14:19:45.373Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/c7/6745d28dbde43cb54a06e57a210eb1af54e6d516b7a2e630a8fe2a1dfe9d/czkawka-0.0.7-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec524ce1a580023ead2ecb21eea09e15d6c0ea6d1ce144abf86800e38be5d15f", size = 3179480, upload-time = "2025-10-20T14:18:18.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a5/d4d55a718c50b4c8713c040dcd0cad765b1ab9f60f80b33ef84a3ac773b3/czkawka-0.0.7-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30046e9115da8d55738a25204bbe85bb996eae8b549eb044366ab34fefa52ad3", size = 3594026, upload-time = "2025-10-20T14:17:32.418Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e0/f7647e4a56af75ea6214aeaa9ab5520d9c410c4428462abe707ac1bccf8f/czkawka-0.0.7-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0492fede843c732d58608c10515a75d256a582c05ae1d0e1f42c3879316fcbf4", size = 3479838, upload-time = "2025-10-20T14:18:23.788Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/0b/6be1234923b1ce42e89bf18ae151c100ca6614bb18709daae6c74ae147a4/czkawka-0.0.7-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f858976a5d50d10ce0b8ef41403227f844d63c2f443eae4baedea11ddfc2996a", size = 3394965, upload-time = "2025-10-20T14:19:33.848Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/e6/a19b932f92590e32011214975229ca4c308c65ddeb5b8625d50462ac4a79/czkawka-0.0.7-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:cfa11a1fb39d41a56f353b9fd91a3602227bfd596217a9d276c9db3118f7ef3b", size = 3192574, upload-time = "2025-10-20T14:19:35.43Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6d/5cfbb3c7d1086fbd04d774cc510c492b59a9071b919e4313ba9baa380fbf/czkawka-0.0.7-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:11cd25b4d19a152e3e5e56725dc72a73ba1f7eded8ccb292566e57da7c98dfcf", size = 3440998, upload-time = "2025-10-20T14:18:01.482Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/f6/e34f2f0db8adafd7301890bb7be85fe438f0d7ace312dcb9593794ccc172/czkawka-0.0.7-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:5a166729e65c1cd66b4c65f9dc00771300d49ea929895dfe3e8efdd8fa03302d", size = 3561050, upload-time = "2025-10-20T14:18:07.985Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/47/9577e285ca8dac699cdbe621ed79ad6f638575bc0a75c1e0afddef69b283/czkawka-0.0.7-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d720a5867db40f595dcc8acd81bdd1c4223a5c0a7891d355753160798b7a886a", size = 3583534, upload-time = "2025-10-20T14:19:37.371Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a36ed68d0288863484d5d97bd7213a5be3ca79055fdf68f5c09e0ae0e427/czkawka-0.1.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ccf0f2fd52c593719e53548007b7394c0b5b061981e4fc06c5e163f785e5adba", size = 3861031, upload-time = "2025-10-20T21:42:33.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0c/927908f7c09d9802e7164e6aa88f7449f771b1d89ad9eba5c55d6b370094/czkawka-0.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf46635036ce8f3f3667edb45b7f4897b2a0bd2520e6eb6266e7f658d27e0ff3", size = 3248348, upload-time = "2025-10-20T21:42:21.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d4/d737a3e28ac88d8cf9655a6324e54a98306d61265f3cbb167b8d674976ce/czkawka-0.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f12572cf7734daa111e418f687dc4e53f2bbc470e93094d3f40b782ddad9b94d", size = 3423928, upload-time = "2025-10-20T21:41:58.519Z" },
+    { url = "https://files.pythonhosted.org/packages/29/fb/21aac9ef0e2497b9909c31e5c0894e51d3acc35085d197be49c783c70b95/czkawka-0.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:393a3f36a395a199f3a1ee9c37686a865357c96dc939e8df5dfc30a782d22201", size = 3875325, upload-time = "2025-10-20T21:43:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7f/f2a68cdbf277e17955563b7cad6abed95c239d7064a9075af5e319e5a943/czkawka-0.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3964cdd5bcdab24164b3d9caa420c47b71e45d20330c2b1b88319e5882ae72b0", size = 3735458, upload-time = "2025-10-20T21:41:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b8/33d8607392bd0599c138ec4647b5cd1f20cc97e378e974e624c1be979f38/czkawka-0.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3536f93d33e2e6a4a365486dadfba931f132bf77a1ee01293c8f66f3d34831d", size = 3649959, upload-time = "2025-10-20T21:41:53.314Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/81/ae7a3d6800a6bcd86b65ea4dd92c65c656fcc47f67a1939e8269418ebd05/czkawka-0.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:132eb3b2d74b71045e0b0f2b1523b5a371e1eb017a2600a2c68411bf1257a3eb", size = 3430275, upload-time = "2025-10-20T21:41:13.881Z" },
+    { url = "https://files.pythonhosted.org/packages/30/24/7b080f559006e601abec27b71763295ef8bc4ef63ea7c8a58d4e5c2766bf/czkawka-0.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:eafd73b77b79ec17c894530f3201c333caf94ccfe8ff2dead982d768e4cdfad1", size = 3687473, upload-time = "2025-10-20T21:43:31.48Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/92/91597237e61078494bf145d1d41ec63dfc2991c95b5a5325388fdda86183/czkawka-0.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:15b43c3bb85820067a458232f2f82de763fa71c60e96517e1f9e542a28df074f", size = 3830682, upload-time = "2025-10-20T21:43:44.38Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/411c9503104e7ce12e481d31344680d967301658125499fff56ba5ca526b/czkawka-0.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9f760289def956d4065df781f40214832d5dc2bd1aaa4231d17d01687842113f", size = 3838420, upload-time = "2025-10-20T21:43:38.647Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/93/65678b60920a50ad804bfe5574dec195144cc0b76f34fcf0f57f5b70915a/czkawka-0.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:e5fd293b3576e0bc550b5aca20784dd47f570e158e938c99b8deda99c517d1da", size = 3296568, upload-time = "2025-10-20T21:42:22.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d6/e75e5674a6345514827d4df46819bc182e8b91cc1bb63f5e3945c4a9186f/czkawka-0.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:72b87241c321ab9fb99c6f02b0939714b11810bf9c156705ea02e956942a3933", size = 3457050, upload-time = "2025-10-20T21:42:49.113Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a1/3ca08f9801f579da56ccc2dec6862076ac8b317f93f787f1724a74821356/czkawka-0.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3b6340eabeab4702eb5c9f588dbe3f47a0c3ce906bce250ef4f51252c4f00d4f", size = 3057359, upload-time = "2025-10-20T21:42:13.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/16/2b5d86b037ff8a0a663fb45152168987a0a3877b35b6d45fe03a1871d975/czkawka-0.1.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1e187e885f46104f4c46a3736c3dca3eaf03171c82d01dfccb95e66b7b9fc6b1", size = 3860855, upload-time = "2025-10-20T21:42:03.727Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a3/1aaeed8d78a74a017cd939f139a63bd522d875013ac7db0c23a2557ccc9b/czkawka-0.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e427508dc444130a7fac7d0207e407c23cde02c27142f1ae0a2022fc1876203", size = 3248473, upload-time = "2025-10-20T21:41:48.658Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a0/e0979cc4b315a270ab02da71c5c2cfd5ce9fade0c84442cce76c85da9cfd/czkawka-0.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:576cce790fbeda68ec539693f71a7e6283cdf3609bf560eb5e0f7ef6fc5a8ed1", size = 3424028, upload-time = "2025-10-20T21:41:28.064Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5f/b0a1569680793c0045a15e89917de781a70e74ba4e5a8d020bd4a1ff72e1/czkawka-0.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df3f1ecbd5897ca58e1d7e78a9f4d76d9519ac9017c65fee1316ee5b57dfec75", size = 3875450, upload-time = "2025-10-20T21:42:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b1/c4f5c5fb8cbb1ddb1859fb6f316f75bd9496097dce65cc1f4ea28f8558b4/czkawka-0.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a1795e52b39b11b8f2237860751c71a322a751f2cf6f4580e9872d0d7ed49fbc", size = 3735040, upload-time = "2025-10-20T21:43:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/8e/bf7f1978c1e13e20dd58e1fa4f51958599db4463701fb21c6caa4b48b017/czkawka-0.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aff2e408376d94b06442fc1e82ff2477b24c1c69392006e45a5601ab4dfbcfc2", size = 3649705, upload-time = "2025-10-20T21:43:23.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/99/8bd496ce4753f927b4dd274cdf5043035662ddeeaef90ad6052fd5caf712/czkawka-0.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fb45f8b510851deee0f2dbcebab829e3d0b7444eec66af3ffd736ba514ff5d32", size = 3430166, upload-time = "2025-10-20T21:42:05.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/da/8b41cec162bfb4f074dee025e4f2ef9a1f63b458e4054d7c5869c4058123/czkawka-0.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:068c807eb0103e621671204bfd9aa1dcfaf9e1c57159785b04bac69d7c657302", size = 3687654, upload-time = "2025-10-20T21:43:04.164Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/7ca390abfd6c2736c86c0b332b30519570b1bc8501d8837e86e5c3abc6d6/czkawka-0.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:71319cfe333ba6a2ca6040e4ce390c347bac825b5575c53ee5adbfe4e0120be1", size = 3830575, upload-time = "2025-10-20T21:42:52.317Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/02/44f00fcf26f550fb0107deaa2e58a316eaac768ff27716fd69eceb913450/czkawka-0.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6798d23c2c3d2166e75b7a3e005bed6cd073096136b7d6d49472eb6c24068bc6", size = 3838376, upload-time = "2025-10-20T21:41:08.25Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fa/8fbf85d184c45de900d465a542f001ce48d4db54e57ddca83354834f3951/czkawka-0.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:a9c7c87c903414b2bf88ed9fa020150f25a4074ce930c8bd06f4f49327f1f67e", size = 3296495, upload-time = "2025-10-20T21:41:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b7/61d455d265bb8a8b950f2feadea102ad6743265847d2fd41fd6bec97ef3a/czkawka-0.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c491370eb23665e57a9e2e0205568e7207237227b20881b235814a12c6e26809", size = 3455294, upload-time = "2025-10-20T21:41:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/61/09/e3307bbdaebca1f722df46c54f4f46818b9fcec6979b487dbeff58dabf3b/czkawka-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9d4daefb30f273c421d24009ee0ce6392debc069e45327b22c6b72ce90a2d96", size = 3055981, upload-time = "2025-10-20T21:42:25.761Z" },
+    { url = "https://files.pythonhosted.org/packages/67/75/a43d69f5c34641e8a269e4432111303ce17342ce1a41ea4b40908c3be62d/czkawka-0.1.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f259e0e631648492c6c5be3e166731fd6449ce8381937376005564e0944aa43b", size = 3860815, upload-time = "2025-10-20T21:43:02.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d0/1e294136ad67cde66bbc424ac3acca29fc0690cdb06875e57dfb6801ec4a/czkawka-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f5b67fd6e9128b011cb439ff4c5049d1e2d013457017807653ee8ccaad551de", size = 3248363, upload-time = "2025-10-20T21:43:11.648Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e9/d56989374bc2fc34dce81e4844f978b600e91134158c6d9401e2fefbc1e3/czkawka-0.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9d72dfeb59234d965e8e6ec82740ac7510b4522ceab01fb30923fa489e4f1cb9", size = 3423849, upload-time = "2025-10-20T21:43:29.37Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/78/ffaf212e38b20dcd12ee71b84d039bea2a8859b34554693ffed3246f5a92/czkawka-0.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f768578825f32fc717f16554e54f279ece9de5aa478e6fc25d2c8cafea6d1af6", size = 3875672, upload-time = "2025-10-20T21:41:34.378Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e3/fd7b7298902feae9dc985578520a44a15e9e06d12454095ca5f6c7a6cd4c/czkawka-0.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9dd1610d292b46ee0173899278cd25ec6bb68506731f8b03eb1d017ba7afeff", size = 3736127, upload-time = "2025-10-20T21:41:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6f/2c3a43e7fa1c803f63113d2496dfa7c02ca6100a4f7c0ebe1e9131e6c014/czkawka-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e190b9a27359c97a6510b71c8905480d9aacf509128f1ac96e1a233d30da23b7", size = 3650048, upload-time = "2025-10-20T21:43:34.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1b/37b775db6a8604940b4b5de144a61b70ba7dfc915b3a8644f7e3510ff8b9/czkawka-0.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bdcd0ef968e59b5d5782f8df44793843a3b31bfc360351b3fb5934d9515a57d9", size = 3429574, upload-time = "2025-10-20T21:42:53.907Z" },
+    { url = "https://files.pythonhosted.org/packages/65/63/fd2d45e1167f8b6472cf090b4212c435dce883a985162139a27308e87c79/czkawka-0.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d4352cd3c012ad6f693cf8675d5693c86056753865a8c62fb3bccd44059b25d3", size = 3687202, upload-time = "2025-10-20T21:43:25.026Z" },
+    { url = "https://files.pythonhosted.org/packages/45/3a/fb79e0823c406c4b92b539266e850a5a35603b960fe5df83b94d27172079/czkawka-0.1.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:91d3db480e815d23bf2f0ebc7a6acb6ec5d66dd7ed6ad66cc35696d581a46773", size = 3830510, upload-time = "2025-10-20T21:41:32.198Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e0/f3a4e9d93acc82e6e22fd78e5532c22265e28fca3232e2f5289b70f81b7e/czkawka-0.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:395aeb6809413975d9cf48c73d771030ece7916391b9e4b062698b1025882739", size = 3838870, upload-time = "2025-10-20T21:41:11.856Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b7/50224fd5bc3f58256a4c568b6d313129c8ae2c261be444c2869f0a65e09c/czkawka-0.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:5cb4fab0e4cb2c965aef48fc74de6a01f39b9e18335555f7dff83b65dba23c9f", size = 3296422, upload-time = "2025-10-20T21:42:31.779Z" },
+    { url = "https://files.pythonhosted.org/packages/70/1b/68ef64aa0efad106295654b906fb53bd4ed44d7888ea43b2ac79fa34b801/czkawka-0.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b3b4b55912f9e6608a71e8fd208da77fa5bbacfe046740f50d019612c9fba1ca", size = 3455580, upload-time = "2025-10-20T21:42:30.119Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/87/65fd51f04fa863998ee27d5853fba676b099f3f17dfbe1e0d5bdba5f1d16/czkawka-0.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:edf3ccbdf50134bceb06a1cb437fe4ff62210a340497b970a0fbe0acc882e440", size = 3055976, upload-time = "2025-10-20T21:41:40.622Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/78aac969a9c98b62e883525d1a080a459f9bfa5d47dc3e6e45842807618d/czkawka-0.1.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:929ede286c7fa9e1fa66c2aa892a7a885f829e2a359c1029ab707ceff91b447f", size = 3860877, upload-time = "2025-10-20T21:43:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/40/ffdf7a0f3a96b80767cb7ab75b1efd8e62c0a7d00b610b2be65140763902/czkawka-0.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68597768985a0215ce85270d4236d11baac288a0c4397b0e1963c67c5f5339d2", size = 3248806, upload-time = "2025-10-20T21:42:39.233Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4f/f9ee215df1ed212305acebd8646ebf318fea07a6e47020e64acf4368f8e3/czkawka-0.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:484468cca05f10fa0dba6b5b9a73e2d6f1de537364a99a2539e7fad649091b60", size = 3424032, upload-time = "2025-10-20T21:43:13.742Z" },
+    { url = "https://files.pythonhosted.org/packages/11/78/f91607a8af7db34bf6362a5244582abe975f9fd2198dfaf13119e45e93ca/czkawka-0.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:82dc6c2bcb23f3b6e5436ae8fe2e543d333aba5d9eaaabff45544517573c24d0", size = 3875764, upload-time = "2025-10-20T21:41:10.212Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a7/c36a91e35fcbc99687ac5169e3c27af31e1f29076e42f072ba632a48df87/czkawka-0.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:19a09e3151c96791badebc80214b769c16a9f66d74d959fe6e088ad58fce2da1", size = 3735810, upload-time = "2025-10-20T21:41:04.386Z" },
+    { url = "https://files.pythonhosted.org/packages/af/41/186e3ffe161a41d8bbbac46facf6b6ac8f47857de94f7d0a1ec99cdc6ba1/czkawka-0.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08b82b0b30245031a3f1fdf23c2f25123fb6e9362a1cdfabae4712ada7b5cd5", size = 3650440, upload-time = "2025-10-20T21:41:26.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/00e0c12c63e5e2ac94fcde4414180f6a7db61883d85d656a40ea5256a22d/czkawka-0.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:55e7aae009337a6292a94d561b90bcf642274ea884113057bb7494c398fa0364", size = 3429816, upload-time = "2025-10-20T21:41:54.869Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7e/e8038747c026e316922c0cbe901a048419ea062578e1e3815bcb6dc9df9d/czkawka-0.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cd958195964a5cb0d29e1ba80813fd3a0144a01c1afac2339b292b2edb1be13b", size = 3687388, upload-time = "2025-10-20T21:42:24.217Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ce/283c4c277cedd8c3796ca4a9727bf04ca314439e4747017b1b2ae4cc0acb/czkawka-0.1.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6af79c78d7f4099d73047a464c0b9ac8ffb1c3956534e396b1d1d0c355255c84", size = 3830465, upload-time = "2025-10-20T21:43:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/42/73/bf7d359cf39d1f4f8e444840ae363573d519877641842444b6717eead0ba/czkawka-0.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:36ac8c09682fddc20a27b950f257809b840b7bc32e1542372984e125ba1852c9", size = 3838992, upload-time = "2025-10-20T21:41:22.386Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2f/93c93fd8029ecda2eb1827f71c63657258c7dbd1294132ea5bf1548fbd20/czkawka-0.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:dc8bc3b605dd96ad918dfc9d2809bfddefa5052d93346b343d9e092f0c1167f6", size = 3296333, upload-time = "2025-10-20T21:42:37.058Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/f5e9959f90aba1bb86d764ca0565147122b49d54cf10081a1b295e4c3b25/czkawka-0.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e8c49d70ed688f6095c72dbd8fffa292f88bf2a68d232dd7a219261097a5de3", size = 3247378, upload-time = "2025-10-20T21:41:06.626Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4b/7f362f1d5889848290bd0c9012afbcbdab792e6a1e569b4699acbdf9ee28/czkawka-0.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:919dfba012bd72d4154b765b4649ccc348707071038e9bce0e1ce8faaad85e4b", size = 3422787, upload-time = "2025-10-20T21:42:15.696Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ed/507df98654177705b5f65596c5b353f6c21a5d0cd507118f3be53090d66f/czkawka-0.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:628b9995eae017f268eeb86454019092f9841549631fd59ce12367479da3d657", size = 3874860, upload-time = "2025-10-20T21:41:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/10/74/f62948bbc6137e0947c98bd3ad5f4cd5481844107456c6ecffe184333354/czkawka-0.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:392b4cdcfdafeb2c694b905f05ffadbfbf69e82c32f91b479fcb6f1edb913eb0", size = 3734653, upload-time = "2025-10-20T21:43:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ce/eed94a1aeff41bdfbb6a073154e5732523a4eea7b3437f67314487de0491/czkawka-0.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55d8cb0616f27b60535b8ab8c788999e8a3ab1ec43e208eff8154609ad8879f0", size = 3429120, upload-time = "2025-10-20T21:42:19.394Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/7d/f9fc25b49b37fbcf5c9753d207d739f0ed03928a786a1ff36a97f3f1736a/czkawka-0.1.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:49e257c42a796a8fea4f02b2eceda83d930cc1d63a223f619c885d94975e2c08", size = 3686250, upload-time = "2025-10-20T21:42:07.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/f5/17230678eae0aa889f3d7cf97cb8f0e0555cdd3b61e3a0b5976d3a8dedde/czkawka-0.1.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:231f33f888016adacfcb7ce8fb66a64aba683ca4b0238690fba68e611a8077eb", size = 3829697, upload-time = "2025-10-20T21:41:36.035Z" },
+    { url = "https://files.pythonhosted.org/packages/42/42/35411320c8fb438d86635fc97850fb00510cbf42d5315cfe9f6a1f2abec3/czkawka-0.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:eb7d2d6a8907490fae202b87e0340aabb1aede48f8337960b1e8b43b26d5d8bc", size = 3838035, upload-time = "2025-10-20T21:41:46.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5e/b928305223f882159deb0eef969b6ba293f194461bce238b5e9b52022ecc/czkawka-0.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:182ac1f5a304511899cc4c414f518903b54222709cb90ab99887e181e0eb7048", size = 3056216, upload-time = "2025-10-20T21:42:28.509Z" },
+    { url = "https://files.pythonhosted.org/packages/25/9c/0189cdb2c7258509238cb1553f7d88ee34ffb70630bca15d37cd6d593a4b/czkawka-0.1.1-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad3fff537201971eeef02a02cb63d5945889871b290ad88dc4d46136cdc7e221", size = 3861111, upload-time = "2025-10-20T21:43:18.825Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/03/d3a2a78626d85ecde6647a9aea980e8f154f7df3167bee30b26396365c90/czkawka-0.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:189d41ebb4f1a9b8f8575812f29f12c4b2a5d1dfe396157b39d9bf359888639b", size = 3650243, upload-time = "2025-10-20T21:41:42.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/fc/9a5abcc81b7bae922166016b367b9361347c5706ed2697b9aea9e0cb435f/czkawka-0.1.1-cp314-cp314-win32.whl", hash = "sha256:a261d5d3bcaf9def58687bb49ff736f7c7ebeffd04d26f8f5df4db53a2660444", size = 3237033, upload-time = "2025-10-20T21:42:12.167Z" },
+    { url = "https://files.pythonhosted.org/packages/28/00/5e204b894f11f049740c66f49b3dcd0ad587c70c58b38ff3fe99806709b1/czkawka-0.1.1-pp311-pypy311_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b9a1622465975a7460042b5c5ea5745321d2ccd3944ce9943fa5c0fd9adba763", size = 3860938, upload-time = "2025-10-20T21:42:59.184Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fa/f787e3c3c0fed9329d3667f51e1ef5a115b3c891c660ec43e5ef5ced1e29/czkawka-0.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e66516e402eb5a4e53d68ffd73fa217d957fb58a49de1ea6f409d5d3a962b0", size = 3248106, upload-time = "2025-10-20T21:41:18.306Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/11/1d298020dbe2969f674e0076d9210a71fa34233b999f7ceff745ab380c3e/czkawka-0.1.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c853f116966477e7eb4cf081d1569d1823c657e56bc63d2cc8d15b97051cab65", size = 3424024, upload-time = "2025-10-20T21:42:00.038Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0b/7470b031d0f4751296928b4560e2eb47b1a14447dc15d864a96b664bff1c/czkawka-0.1.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:622f7a36c40d7fdb199d9bbd8e376d39fa946f97e67af1552b0994b6347e28ce", size = 3875302, upload-time = "2025-10-20T21:42:40.844Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/97/a53f2b01bd7a57759dcf83d28a679aaff17707c7642ef6bb78bcdc61b8e6/czkawka-0.1.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ff726346e7825c2b003948c2f29d76de70d7af736a138c4e1d9387f45e98c10d", size = 3734765, upload-time = "2025-10-20T21:42:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9e/7e7a6612a769f01de428705933ce5f47d739f461db4de112107bc922ebc4/czkawka-0.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dde24e79cb79a58917249032db605beb8fe58ea3bf7ff5d16cfa6d6621c0c572", size = 3649483, upload-time = "2025-10-20T21:42:10.379Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e0/172c9fc763544fc25aff4960b927bcaef90ad98eb3330a6fa0420e0d39ed/czkawka-0.1.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:44d1cdcff716f60480b2101c4ff9c588caefc82fdaf0d3e23394a70f59ce9d34", size = 3429479, upload-time = "2025-10-20T21:43:27.242Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/38/9d72eb7a187cdd2334e3c3e17301625a672dd3f88a609eb6467b765c664a/czkawka-0.1.1-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:73600c3e3179cf1e5e00474dc83984aef2f501eec2c2b262ba16392193a29901", size = 3687334, upload-time = "2025-10-20T21:41:30.584Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ed/efa809d62ab925a520a85780fb234918c3316252b5c7736ae052aeb276fd/czkawka-0.1.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:23b82f0668476708cadf98ab8ff985e9d9deca911e652f2465a1a87715072852", size = 3830639, upload-time = "2025-10-20T21:42:35.338Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/2f/4126cc91616f03bb683ffbaeeb6029f831d646f643a08e1318114c0cd7da/czkawka-0.1.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:223a3f05392123fcd5e9cb0b55d33486b717c4861b33fcdd9a691b45b5f5f24c", size = 3838288, upload-time = "2025-10-20T21:42:08.737Z" },
 ]
 
 [[package]]
@@ -478,6 +487,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883, upload-time = "2024-07-12T22:26:00.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453, upload-time = "2024-07-12T22:25:58.476Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fancycompleter"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "pyrepl", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/4c/d11187dee93eff89d082afda79b63c79320ae1347e49485a38f05ad359d0/fancycompleter-0.11.1.tar.gz", hash = "sha256:5b4ad65d76b32b1259251516d0f1cb2d82832b1ff8506697a707284780757f69", size = 341776, upload-time = "2025-05-26T12:59:11.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/c3/6f0e3896f193528bbd2b4d2122d4be8108a37efab0b8475855556a8c4afa/fancycompleter-0.11.1-py3-none-any.whl", hash = "sha256:44243d7fab37087208ca5acacf8f74c0aa4d733d04d593857873af7513cdf8a6", size = 11207, upload-time = "2025-05-26T12:59:09.857Z" },
 ]
 
 [[package]]
@@ -669,6 +700,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
+]
+
+[[package]]
+name = "inline-snapshot"
+version = "0.30.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pytest" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/89/125e7411ded6fda4c3881674dd815aaa175cd3f822a1e215edab491024b9/inline_snapshot-0.30.1.tar.gz", hash = "sha256:77c2e94a40f2da02909b39e3386c9fc23f532c92af45558e2d7bbabb5fd0cbc1", size = 2599126, upload-time = "2025-10-20T11:02:58.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/d8/1c4a926d1201be6a453c1efa795d6ca58735783b017e4ef78536879e82e9/inline_snapshot-0.30.1-py3-none-any.whl", hash = "sha256:4e65fe9d6d266d5dcbab9a75aef65ade386ba257238e30e11ce4cebf9a4312c8", size = 71265, upload-time = "2025-10-20T11:02:57.063Z" },
 ]
 
 [[package]]
@@ -1341,6 +1388,7 @@ build = [
     { name = "patchelf" },
 ]
 dev = [
+    { name = "pdbpp" },
     { name = "pdm" },
     { name = "pdm-bump" },
     { name = "pre-commit" },
@@ -1361,6 +1409,7 @@ docs = [
 ]
 test = [
     { name = "czkawka" },
+    { name = "inline-snapshot" },
     { name = "pytest" },
 ]
 
@@ -1380,6 +1429,7 @@ build = [
     { name = "patchelf", specifier = ">=0.17.2.4" },
 ]
 dev = [
+    { name = "pdbpp", specifier = ">=0.11.7" },
     { name = "pdm", specifier = ">=2.22.3" },
     { name = "pdm-bump", specifier = ">=0.9.10" },
     { name = "pre-commit", specifier = ">=4.1.0" },
@@ -1399,7 +1449,8 @@ docs = [
     { name = "urllib3", specifier = "<2" },
 ]
 test = [
-    { name = "czkawka", specifier = ">=0.0.7" },
+    { name = "czkawka", specifier = ">=0.1.1" },
+    { name = "inline-snapshot", specifier = ">=0.30.1" },
     { name = "pytest", specifier = ">=7.4.0" },
 ]
 
@@ -1444,6 +1495,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/84/a6/21f16530c74911333fc6007a218e5992b74e5506bc1f0272f4afdd74c3b8/pbs_installer-2025.2.5.tar.gz", hash = "sha256:e2d75530fe49b814dc98baf6bbd960a21f43521006439c4f5bebe4d4ab8c07da", size = 51116, upload-time = "2025-02-06T08:00:19.603Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/7f/64622169d85279ddc847bbde463f28a308e5ae9b632383bc90944c4a0b6b/pbs_installer-2025.2.5-py3-none-any.whl", hash = "sha256:8494fa6499ec10243fdd79e874aef756777b2cd0e5ca0c1df69a2d768b42dab4", size = 52561, upload-time = "2025-02-06T08:00:17.991Z" },
+]
+
+[[package]]
+name = "pdbpp"
+version = "0.11.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fancycompleter" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/4c/118ef9534ac0632859b48c305d8c5dc9d6f963564fdfa66bc785c560247c/pdbpp-0.11.7.tar.gz", hash = "sha256:cb6604ac31a35ed0f2a29650a8c022b26284620be3e01cfd41b683b91da1ff14", size = 76026, upload-time = "2025-07-18T09:36:02.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/e9/704bbc08aace64fee536e4c2c20f63f64f6fdbad72938c5ed46c9723a9f1/pdbpp-0.11.7-py3-none-any.whl", hash = "sha256:51916b63693898cf4881b36b4501c83947758d73f582f1f84893662b163bdb75", size = 30545, upload-time = "2025-07-18T09:36:01.478Z" },
 ]
 
 [[package]]
@@ -1664,6 +1728,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pyrepl"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/4f/7088417e5465c53a30b918d30542aad89352ea0d635a5d077717c69a7d2b/pyrepl-0.11.4.tar.gz", hash = "sha256:efe988b4a6e5eed587e9769dc2269aeec2b6feec2f5d77995ee85b9ad7cf7063", size = 51089, upload-time = "2025-07-17T22:56:25.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/a5/ce97a778f096aaa27cfcb7ad09f1198cf73277dcab6c68a4b8f332d91e48/pyrepl-0.11.4-py3-none-any.whl", hash = "sha256:ac30d6340267a21c39e1b1934f92bca6b8735017d14b17e40f903b2d1563541d", size = 55596, upload-time = "2025-07-17T22:56:24.537Z" },
+]
+
+[[package]]
 name = "pysnooper"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1674,7 +1756,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1682,11 +1764,12 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/8c/9862305bdcd6020bc7b45b1b5e7397a6caf1a33d3025b9a003b39075ffb2/pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce", size = 1439314, upload-time = "2024-07-25T10:40:00.159Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/f9/cf155cf32ca7d6fa3601bc4c5dd19086af4b320b706919d48a4c79081cf9/pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5", size = 341802, upload-time = "2024-07-25T10:39:57.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **chore: use standard dep groups**
- **chore: add czkawka dev dep**
- **refactor: hash images with czkawka**

Working on improvements to tests for #71