### PR TITLE
docs: amend all the docstring bullet and numbered lists

### DIFF
--- a/src/page_dewarp/cli.py
+++ b/src/page_dewarp/cli.py
@@ -50,15 +50,17 @@ class ArgParser(argparse.ArgumentParser):
     ):
         """Add an argument with defaults coming from the global config.
 
-        :param name_or_flags: Short or long flags (e.g. ["-d", "--debug-level"]).
-        :param arg_name: Name used as the config key.
-        :param action: An argparse action (store, store_true, etc.).
-        :param help: Help text for argparse.
-        :param const: A constant value for certain actions (store_const, etc.).
-        :param choices: Possible choices for this argument.
-        :param nargs: Number of args that this argument consumes.
-        :param metavar: The name to display in usage messages.
-        :param required: Whether the argument is required.
+        Args:
+            name_or_flags (list[str]): Short or long flags, e.g. `["-d", "--debug-level"]`.
+            arg_name (str): Name used as the config key.
+            action (str): Argparse action (`store`, `store_true`, etc.).
+            help (str): Help text for argparse.
+            const (Any): Constant value for actions such as `store_const`.
+            choices (list | tuple): Allowed values for this argument.
+            nargs (int | str): Number of arguments consumed.
+            metavar (str): Display name in usage messages.
+            required (bool): Whether the argument is required.
+
         """
         kwargs = {
             "action": action,

--- a/src/page_dewarp/contours.py
+++ b/src/page_dewarp/contours.py
@@ -1,6 +1,7 @@
 """Utilities for detecting, filtering, and analyzing contours within images.
 
 This module provides functions to:
+
 - Find external contours in a binary mask,
 - Calculate centroid and orientation for each contour (via SVD on central moments),
 - Filter contours by size and shape,
@@ -55,8 +56,10 @@ def blob_mean_and_tangent(contour: np.ndarray) -> tuple[np.ndarray, np.ndarray] 
 
     Returns:
         A tuple `(center, tangent)` where:
+
             - `center` is (x, y) for the contour's centroid,
             - `tangent` is the principal orientation as a unit vector.
+
         Returns `None` if the contour area is zero.
 
     """

--- a/src/page_dewarp/dewarp.py
+++ b/src/page_dewarp/dewarp.py
@@ -1,6 +1,7 @@
 """Remapping and thresholding logic for page dewarping.
 
 This module provides:
+
 - A helper function, `round_nearest_multiple`, to round integers up to the nearest multiple.
 - A `RemappedImage` class that transforms (remaps) an input image to a
   rectified, thresholded output using a cubic parameterization of the page.

--- a/src/page_dewarp/image.py
+++ b/src/page_dewarp/image.py
@@ -1,6 +1,7 @@
 """Utilities for loading, resizing, and dewarping page images.
 
 This module includes:
+
 - A simple helper function (`imgsize`) to format an image's width/height into a string.
 - A function (`get_page_dims`) to optimize final page dimensions via the cubic model.
 - A class (`WarpedImage`) that loads an image, resizes it, finds page boundaries,

--- a/src/page_dewarp/keypoints.py
+++ b/src/page_dewarp/keypoints.py
@@ -1,6 +1,7 @@
 """Keypoint indexing and projection utilities.
 
 This module provides helper functions to:
+
 - Generate a "keypoint index" array from span counts (for referencing parameters).
 - Project keypoints (in a parameter vector) into 2D coordinates using a cubic model.
 """

--- a/src/page_dewarp/mask.py
+++ b/src/page_dewarp/mask.py
@@ -1,6 +1,7 @@
 """Mask creation and manipulation for page regions and text/line detection.
 
 This module provides:
+
 - A helper function (`box`) to generate structuring elements for morphological ops.
 - A `Mask` class, which thresholds the page image, applies morphological operations,
   and blends the resulting mask with a page mask.
@@ -67,6 +68,7 @@ class Mask:
         """Apply adaptive thresholding and morphological ops to create `self.value`.
 
         Steps:
+
         1. Convert `self.small` to grayscale.
         2. Use an adaptive threshold (binary inverse).
         3. Depending on `self.text`, either dilate or erode the result, log intermediate steps.

--- a/src/page_dewarp/normalisation.py
+++ b/src/page_dewarp/normalisation.py
@@ -1,6 +1,7 @@
 """Pixel-to-normalized (and vice versa) coordinate transformations.
 
 This module provides:
+
 - `pix2norm`: Convert pixel coordinates in an image to normalized coordinates.
 - `norm2pix`: Convert normalized coordinates back into pixel coordinates.
 """

--- a/src/page_dewarp/optimise.py
+++ b/src/page_dewarp/optimise.py
@@ -1,6 +1,7 @@
 """Parameter optimization routines for page dewarping.
 
 This module provides:
+
 - A function (`draw_correspondences`) to visualize matched points (dstpoints/projpts).
 - A function (`optimise_params`) that uses an objective function and scipy's `minimize`
   to refine the parameter vector for page dewarping.

--- a/src/page_dewarp/options/core.py
+++ b/src/page_dewarp/options/core.py
@@ -1,6 +1,7 @@
 """Core configuration structures for page-dewarp.
 
 Defines:
+
 - A helper function (`desc`) that annotates msgspec.Struct fields with a description.
 - A global `Config` class specifying various parameters (camera, edge detection, etc.).
 """

--- a/src/page_dewarp/projection.py
+++ b/src/page_dewarp/projection.py
@@ -1,6 +1,7 @@
 """Project 3D points into image space using a cubic warp model.
 
 This module provides a `project_xy` function, which:
+
 - Constructs a cubic polynomial from alpha/beta slopes.
 - Uses OpenCV's `projectPoints` to map the resulting 3D points into image coordinates.
 """

--- a/src/page_dewarp/solve.py
+++ b/src/page_dewarp/solve.py
@@ -1,6 +1,7 @@
 """Parameter initialization and solve routines for page flattening.
 
 This module contains a function (`get_default_params`) that:
+
 - Uses four corner correspondences to estimate rotation/translation (solvePnP).
 - Includes default cubic slopes and any y/x coordinates from sampled spans.
 """

--- a/src/page_dewarp/spans.py
+++ b/src/page_dewarp/spans.py
@@ -1,6 +1,7 @@
 """Spanning and keypoint logic for page dewarping.
 
 This module handles:
+
 - Determining candidate edges between adjacent contours to form "spans."
 - Grouping individual contours into spans.
 - Sampling keypoint positions along spans.


### PR DESCRIPTION
Get the lists correct without plugins, and parameters (only a few)
