### PR TITLE
feat: allow all SciPy minimize methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ by Matt Zucker, as Python 2 is now long since decommissioned.
 
 ```
 usage: page-dewarp [-h] [-d {0,1,2,3}] [-o {file,screen,both}] [-p]
-                   [-it OPT_MAX_ITER] [-vw SCREEN_MAX_W] [-vh SCREEN_MAX_H]
-                   [-x PAGE_MARGIN_X] [-y PAGE_MARGIN_Y] [-tw TEXT_MIN_WIDTH]
-                   [-th TEXT_MIN_HEIGHT] [-ta TEXT_MIN_ASPECT]
-                   [-tk TEXT_MAX_THICKNESS] [-wz ADAPTIVE_WINSZ]
-                   [-ri RVEC_IDX] [-ti TVEC_IDX] [-ci CUBIC_IDX]
-                   [-sw SPAN_MIN_WIDTH] [-sp SPAN_PX_PER_STEP]
+                   [-it OPT_MAX_ITER] [-m OPT_METHOD] [-vw SCREEN_MAX_W]
+                   [-vh SCREEN_MAX_H] [-x PAGE_MARGIN_X] [-y PAGE_MARGIN_Y]
+                   [-tw TEXT_MIN_WIDTH] [-th TEXT_MIN_HEIGHT]
+                   [-ta TEXT_MIN_ASPECT] [-tk TEXT_MAX_THICKNESS]
+                   [-wz ADAPTIVE_WINSZ] [-ri RVEC_IDX] [-ti TVEC_IDX]
+                   [-ci CUBIC_IDX] [-sw SPAN_MIN_WIDTH] [-sp SPAN_PX_PER_STEP]
                    [-eo EDGE_MAX_OVERLAP] [-el EDGE_MAX_LENGTH]
                    [-ec EDGE_ANGLE_COST] [-ea EDGE_MAX_ANGLE]
                    [-f FOCAL_LENGTH] [-z OUTPUT_ZOOM] [-dpi OUTPUT_DPI]
@@ -66,6 +66,9 @@ options:
   -it, --max-iter OPT_MAX_ITER
                         Maximum Powell's method optimisation iterations (type:
                         int, default: 600000)
+  -m, --method OPT_METHOD
+                        Name of the SciPy optimisation method to use. (type:
+                        str, default: Powell)
   -vw, --max-screen-width SCREEN_MAX_W
                         Viewing screen max width (for resizing to screen)
                         (type: int, default: 1280)

--- a/src/page_dewarp/cli.py
+++ b/src/page_dewarp/cli.py
@@ -145,6 +145,7 @@ class ArgParser(argparse.ArgumentParser):
             help="Merge images into a PDF",
         )
         self.add_default_argument(["-it", "--max-iter"], "OPT_MAX_ITER")
+        self.add_default_argument(["-m", "--method"], "OPT_METHOD")
         self.add_default_argument(["-vw", "--max-screen-width"], "SCREEN_MAX_W")
         self.add_default_argument(["-vh", "--max-screen-height"], "SCREEN_MAX_H")
         self.add_default_argument(["-x", "--x-margin"], "PAGE_MARGIN_X")

--- a/src/page_dewarp/optimise.py
+++ b/src/page_dewarp/optimise.py
@@ -90,7 +90,7 @@ def optimise_params(
     min_opts = {"maxiter": cfg.OPT_MAX_ITER}
     print(f"  optimizing {len(params)} parameters (max. {cfg.OPT_MAX_ITER}x)...")
     start = dt.now()
-    res = minimize(objective, params, method="Powell", options=min_opts)
+    res = minimize(objective, params, method=cfg.OPT_METHOD, options=min_opts)
     end = dt.now()
     print(f"  optimization took {round((end - start).total_seconds(), 2)} sec.")
     print(f"  final objective is {res.fun}")

--- a/src/page_dewarp/options/core.py
+++ b/src/page_dewarp/options/core.py
@@ -32,6 +32,7 @@ class Config(Struct):
 
     Attributes:
         OPT_MAX_ITER (int): Maximum Powell's method optimisation iterations.
+        OPT_METHOD (str): Name of the SciPy optimisation method to use.
         FOCAL_LENGTH (float): Normalized focal length of camera.
         TEXT_MIN_WIDTH (int): Minimum reduced pixel width of detected text contour.
         TEXT_MIN_HEIGHT (int): Minimum reduced pixel height of detected text contour.
@@ -75,6 +76,33 @@ class Config(Struct):
 
        Powell's method is slower than methods like L-BFGS-B, but it avoids local minima
        better in high-dimensional parameter spaces.
+    """
+    OPT_METHOD: desc(str, "Name of the SciPy optimisation method to use.") = "Powell"
+    """
+    Name of the SciPy optimisation method to use.
+
+    Note:
+       This name is passed as `method` to
+       [scipy.optimize.minimize](https://docs.scipy.org/doc/scipy/reference/optimize.minimize.html),
+       and defaults to `"Powell"` if unset.
+
+       All options:
+
+       - Nelder-Mead
+       - Powell
+       - CG
+       - BFGS
+       - Newton-CG
+       - L-BFGS-B
+       - TNC
+       - COBYLA
+       - COBYQA
+       - SLSQP
+       - trust-const
+       - dogleg
+       - trust-ncg
+       - trust-exact
+       - trust-krylov
     """
     # [camera_opts]
     FOCAL_LENGTH: desc(float, "Normalized focal length of camera") = 1.2


### PR DESCRIPTION
I don't think I want to change the default (#101), but for testing it can be useful to switch to another method than Powell