### PR TITLE
Add LICENSE to the source distributable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,3 +143,6 @@ default-groups = ["build", "dev", "jax", "test"]
 
 [tool.uv.sources]
 mdx-truly-sane-lists = { git = "https://github.com/radude/mdx_truly_sane_lists.git" }
+
+[tool.uv.build-backend]
+source-include = ["LICENSE"]


### PR DESCRIPTION
This PR adds the LICENSE file back to the source package distribution. It was previously available in `0.2.7` but disappeared after the switch to `uv` as build backend. Fixes #166.